### PR TITLE
add CPT archive link to widget options and output.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 WordPress plugin that adds a widget to display Featured Custom Post Types for the Genesis Framework
 
-## Description 
+## Description
 
 WordPress plugin that adds a widget to display Featured Custom Post Types for the Genesis Framework. Supports Custom Taxonomies.
 
@@ -12,6 +12,7 @@ Genesis 2.0+
 
 ## Credits
 Most of the code in this plugin is from the <a href="http://www.studiopress.com/">StudioPress</a> Genesis Featured Post Widget and I've just added Custom Post Type Support.
+
 Thanks to <a href="https://github.com/ahnlak">Pete Favelle</a> for adding Custom Taxonomy support.
 
 ## Installation
@@ -39,3 +40,17 @@ Using git, browse to your /wp-content/plugins/ directory and clone this reposito
 git clone git@github.com:calliaweb/genesis-featured-custom-post-type-widget.git
 
 Then go to your Plugins screen and click Activate.
+
+### Credits
+* [Jo Waltham](http://calliaweb.co.uk/)
+* with help from [Pete Favelle](https://github.com/ahnlak)
+* and [Robin Cornett](http://robincornett.com)
+
+### Changelog
+
+#### 1.2.0
+* new option for CPT archive link
+* set ajax to load conditionally
+
+#### 1.0.0
+* initial release on GH

--- a/featured-custom-post-type-widget.php
+++ b/featured-custom-post-type-widget.php
@@ -9,7 +9,7 @@
  * Plugin Name: Featured Custom Post Type Widget for Genesis
  * Plugin URI:  http://calliaweb.co.uk/featured-custom-post-type-widget-genesis/
  * Description: Widget to Display Featured Custom Post Types - uses code from Genesis Featured Post Widget and adds support for custom post types and custom taxonomies
- * Version:     1.1.1
+ * Version:     1.2.0
  * Author:      Jo Waltham
  * Author URI:  http://calliaweb.co.uk/
  * Text Domain: featured-custom-post-type-widget-for-genesis
@@ -19,14 +19,14 @@
 */
 
 // if this file is called directly abort
-if ( ! defined('WPINC' )) {
+if ( ! defined('WPINC' ) ) {
 	die;
 }
- 
+
  // Register the widget
 add_action( 'widgets_init', 'gfcptw_register_widget' );
 function gfcptw_register_widget() {
-	register_widget( 'Genesis_Featured_Custom_Post_Type');
+	register_widget( 'Genesis_Featured_Custom_Post_Type' );
 }
- 
+
 require plugin_dir_path( __FILE__ ) . 'includes/class-featured-custom-post-type-widget-registrations.php';

--- a/includes/class-featured-custom-post-type-widget-registrations.php
+++ b/includes/class-featured-custom-post-type-widget-registrations.php
@@ -3,20 +3,12 @@
  * Featured Custom Post Type Widget For Genesis
  *
  * @package FeaturedCustomPostTypeWidgetForGenesis
- * @author 	StudioPress
- * @author 	Jo Waltham
+ * @author  StudioPress
+ * @author  Jo Waltham
  * @author  Pete Favelle
+ * @author  Robin Cornett
  * @license GPL-2.0+
  *
- */
-
- /**
- * Register Featured Custom Post Type Widget For Genesis
- *
- * @package FeaturedCustomPostTypeWidgetForGenesis
- * @author 	StudioPress
- * @author	Jo Waltham
- * @author  Pete Favelle
  */
 
  /**
@@ -323,7 +315,7 @@ class Genesis_Featured_Custom_Post_Type extends WP_Widget {
 
 		// Fetch a list of possible post types
 		$args = array(
-			'public' => true,
+			'public'   => true,
 			'_builtin' => false,
 		);
 		$output = 'names';
@@ -331,7 +323,7 @@ class Genesis_Featured_Custom_Post_Type extends WP_Widget {
 		$post_type_list = get_post_types( $args, $output, $operator );
 
 		// Add posts to that post_type_list
-		$post_type_list[ 'post' ] = 'post';
+		$post_type_list['post'] = 'post';
 
 		// And a list of available taxonomies for the current post type
 		if ( 'any' == $instance['post_type'] ) {
@@ -342,7 +334,7 @@ class Genesis_Featured_Custom_Post_Type extends WP_Widget {
 
 		// And from there, a list of available terms in that tax
 		$tax_args = array(
-			'hide_empty'	=> 0,
+			'hide_empty' => 0,
 		);
 		$tax_term_list = get_terms( $taxonomies, $tax_args );
 		usort( $tax_term_list, array( $this, 'tax_term_compare' ) );


### PR DESCRIPTION
Since there is a `get_post_type_archive_link` function, it makes sense to have an option to show the CPT archive, pretty please.
