### PR TITLE
deactivates if Genesis isn't active

### DIFF
--- a/featured-custom-post-type-widget.php
+++ b/featured-custom-post-type-widget.php
@@ -23,7 +23,25 @@ if ( ! defined('WPINC' ) ) {
 	die;
 }
 
- // Register the widget
+add_action( 'init', 'gfcptw_init' );
+function gfcptw_init() {
+	if ( 'genesis' !== basename( get_template_directory() ) ) {
+		add_action( 'admin_init', 'gfcptw_deactivate' );
+		add_action( 'admin_notices', 'gfcptw_notice' );
+		return;
+	}
+
+}
+
+function gfcptw_deactivate() {
+	deactivate_plugins( plugin_basename( __FILE__ ) );
+}
+
+function gfcptw_notice() {
+	echo '<div class="error"><p><strong>Featured Custom Post Type Widget For Genesis</strong> works only with the Genesis Framework. It has been <strong>deactivated</strong>.</p></div>';
+}
+
+// Register the widget
 add_action( 'widgets_init', 'gfcptw_register_widget' );
 function gfcptw_register_widget() {
 	register_widget( 'Genesis_Featured_Custom_Post_Type' );


### PR DESCRIPTION
Jo, added in simple check to see if Genesis is active, and if not, to deactivate. Could alternatively check something like `if ( class_exists( 'Genesis_Featured_Post' ) )`, but I didn't test/try that as this seemed to work.
