### PR TITLE
Add Column Classes to Widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Check out the Codex for more information about [installing plugins manually](htt
 
 Using git, browse to your /wp-content/plugins/ directory and clone this repository:
 
-git clone git@github.com:calliaweb/genesis-featured-custom-post-type-widget.git
+git clone git@github.com:calliaweb/featured-custom-post-type-widget-for-genesis.git
 
 Then go to your Plugins screen and click Activate.
 
@@ -57,6 +57,10 @@ If you are having styling issues with the columns, try adding this to your style
 * and [Robin Cornett](http://robincornett.com)
 
 ### Changelog
+
+#### 2.0.0
+* new feature: display posts in columns within the widget
+* bugfix: ajax list now sorts properly
 
 #### 1.2.0
 * new option for CPT archive link

--- a/README.md
+++ b/README.md
@@ -41,6 +41,16 @@ git clone git@github.com:calliaweb/genesis-featured-custom-post-type-widget.git
 
 Then go to your Plugins screen and click Activate.
 
+## Frequently Asked Questions
+
+If you are having styling issues with the columns, try adding this to your stylesheet:
+
+```css
+.sidebar .widget {
+	overflow: hidden;
+}
+```
+
 ### Credits
 * [Jo Waltham](http://calliaweb.co.uk/)
 * with help from [Pete Favelle](https://github.com/ahnlak)

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Then go to your Plugins screen and click Activate.
 If you are having styling issues with the columns, try adding this to your stylesheet:
 
 ```css
-.sidebar .widget {
+.widget {
 	overflow: hidden;
 }
 ```

--- a/featured-custom-post-type-widget.php
+++ b/featured-custom-post-type-widget.php
@@ -38,13 +38,25 @@ function gfcptw_deactivate() {
 }
 
 function gfcptw_notice() {
-	echo '<div class="error"><p><strong>Featured Custom Post Type Widget For Genesis</strong> works only with the Genesis Framework. It has been <strong>deactivated</strong>.</p></div>';
+	echo '<div class="error"><p>';
+	echo __( '<strong>Featured Custom Post Type Widget For Genesis</strong> works only with the Genesis Framework. It has been <strong>deactivated</strong>.', 'featured-custom-post-type-widget-for-genesis' );
+	echo '</p></div>';
 }
 
 // Register the widget
 add_action( 'widgets_init', 'gfcptw_register_widget' );
 function gfcptw_register_widget() {
 	register_widget( 'Genesis_Featured_Custom_Post_Type' );
+}
+
+add_action( 'plugins_loaded', 'gfcptw_load_textdomain' );
+/**
+ * Set up text domain for translations
+ *
+ * @since 2.0.0
+ */
+function gfcptw_load_textdomain() {
+	load_plugin_textdomain( 'featured-custom-post-type-widget-for-genesis', false, plugin_basename( __FILE__ ) . '/languages/' );
 }
 
 require plugin_dir_path( __FILE__ ) . 'includes/class-featured-custom-post-type-widget-registrations.php';

--- a/includes/ajax_handler.js
+++ b/includes/ajax_handler.js
@@ -15,8 +15,7 @@ function tax_term_postback( select_id, post_type ) {
 	select_ctrl.empty();
 	jQuery.each(terms, function(key, value) {
 		var new_option = jQuery('<option></option>')
-					    .attr('style', 'padding-right:10px;')
-					    .attr('value', key).text(value);
+		    .attr('value', key).text(value);
 		if (value == old_term) {
 			new_option.attr('selected', true);
 		}

--- a/includes/class-featured-custom-post-type-widget-registrations.php
+++ b/includes/class-featured-custom-post-type-widget-registrations.php
@@ -51,21 +51,21 @@ class Genesis_Featured_Custom_Post_Type extends WP_Widget {
 			'gravatar_size'           => '',
 			'show_title'              => 0,
 			'show_byline'             => 0,
-			'post_info'               => '[post_date] ' . __( 'By', 'genesis-featured-custom-post-type-widget' ) . ' [post_author_posts_link] [post_comments]',
+			'post_info'               => '[post_date] ' . __( 'By', 'featured-custom-post-type-widget-for-genesis' ) . ' [post_author_posts_link] [post_comments]',
 			'show_content'            => 'excerpt',
 			'content_limit'           => '',
-			'more_text'               => __( '[Read More...]', 'genesis-featured-custom-post-type-widget' ),
+			'more_text'               => __( '[Read More...]', 'featured-custom-post-type-widget-for-genesis' ),
 			'extra_num'               => '',
 			'extra_title'             => '',
 			'more_from_category'      => '',
-			'more_from_category_text' => __( 'More Posts from this Category', 'genesis-featured-custom-post-type-widget' ),
+			'more_from_category_text' => __( 'More Posts from this Category', 'featured-custom-post-type-widget-for-genesis' ),
 			'archive_link'            => '',
-			'archive_text'            => __( 'View Custom Post Type Archive', 'genesis-featured-custom-post-type-widget' ),
+			'archive_text'            => __( 'View Custom Post Type Archive', 'featured-custom-post-type-widget-for-genesis' ),
 		);
 
 		$widget_ops = array(
 			'classname'   => 'featured-content featuredpost',
-			'description' => __( 'Displays featured custom post types with thumbnails', 'genesis-featured-custom-post-type-widget' ),
+			'description' => __( 'Displays featured custom post types with thumbnails', 'featured-custom-post-type-widget-for-genesis' ),
 		);
 
 		$control_ops = array(
@@ -74,7 +74,7 @@ class Genesis_Featured_Custom_Post_Type extends WP_Widget {
 			'height'  => 350,
 		);
 
-		parent::__construct( 'featured-custom-post-type', __( 'Featured Custom Post Types for Genesis', 'genesis-featured-custom-post-type-widget' ), $widget_ops, $control_ops );
+		parent::__construct( 'featured-custom-post-type', __( 'Featured Custom Post Types for Genesis', 'featured-custom-post-type-widget-for-genesis' ), $widget_ops, $control_ops );
 
 		// Register our Ajax handler
 		add_action( 'wp_ajax_tax_term_action', array( $this, 'tax_term_action_callback' ) );
@@ -325,7 +325,7 @@ class Genesis_Featured_Custom_Post_Type extends WP_Widget {
 
 		?>
 		<p>
-			<label for="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>"><?php _e( 'Title:', 'genesis-featured-custom-post-type-widget' ); ?> </label>
+			<label for="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>"><?php _e( 'Title:', 'featured-custom-post-type-widget-for-genesis' ); ?> </label>
 			<input type="text" id="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'title' ) ); ?>" value="<?php echo esc_attr( $instance['title'] ); ?>" class="widefat" />
 		</p>
 
@@ -334,11 +334,11 @@ class Genesis_Featured_Custom_Post_Type extends WP_Widget {
 			<div class="genesis-widget-column-box genesis-widget-column-box-top">
 
 				<p>
-					<label for="<?php echo esc_attr( $this->get_field_id( 'post_type' ) ); ?>"><?php _e( 'Post Type:', 'genesis-featured-custom-post-type-widget' ); ?> </label>
+					<label for="<?php echo esc_attr( $this->get_field_id( 'post_type' ) ); ?>"><?php _e( 'Post Type:', 'featured-custom-post-type-widget-for-genesis' ); ?> </label>
 					<select id="<?php echo esc_attr( $this->get_field_id( 'post_type' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'post_type' ) ); ?>" onchange="tax_term_postback('<?php echo esc_attr( $this->get_field_id( 'tax_term' ) ); ?>', this.value);" >
 
 						<?php
-						echo '<option value="any" '. selected( 'any', $instance['post_type'], false ) .'>'. __( 'any', 'genesis-featured-custom-post-type-widget' ) .'</option>';
+						echo '<option value="any" '. selected( 'any', $instance['post_type'], false ) .'>'. __( 'any', 'featured-custom-post-type-widget-for-genesis' ) .'</option>';
 						foreach ( $item->post_type_list as $post_type_item ) {
 							echo '<option value="'. esc_attr( $post_type_item ) .'"'. selected( esc_attr( $post_type_item ), $instance['post_type'], false ) .'>'. esc_attr( $post_type_item ) .'</option>';
 						}
@@ -348,11 +348,11 @@ class Genesis_Featured_Custom_Post_Type extends WP_Widget {
 				</p>
 
 				<p>
-					<label for="<?php echo esc_attr( $this->get_field_id( 'tax_term' ) ); ?>"><?php _e( 'Category/Term:', 'genesis-featured-custom-post-type-widget' ); ?> </label>
+					<label for="<?php echo esc_attr( $this->get_field_id( 'tax_term' ) ); ?>"><?php _e( 'Category/Term:', 'featured-custom-post-type-widget-for-genesis' ); ?> </label>
 					<select id="<?php echo esc_attr( $this->get_field_id( 'tax_term' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'tax_term' ) ); ?>">
 
 						<?php
-						echo '<option value="any" '. selected( 'any', $instance['tax_term'], false ) .'>'. __( 'any', 'genesis-featured-custom-post-type-widget' ) .'</option>';
+						echo '<option value="any" '. selected( 'any', $instance['tax_term'], false ) .'>'. __( 'any', 'featured-custom-post-type-widget-for-genesis' ) .'</option>';
 						foreach ( $item->tax_term_list as $tax_term_item ) {
 							$tax_term_desc = $tax_term_item->taxonomy . '/' . $tax_term_item->name;
 							$tax_term_slug = $tax_term_item->taxonomy . '/' . $tax_term_item->slug;
@@ -364,42 +364,42 @@ class Genesis_Featured_Custom_Post_Type extends WP_Widget {
 				</p>
 
 				<p>
-					<label for="<?php echo esc_attr( $this->get_field_id( 'posts_num' ) ); ?>"><?php _e( 'Number of Posts to Show:', 'genesis-featured-custom-post-type-widget' ); ?> </label>
+					<label for="<?php echo esc_attr( $this->get_field_id( 'posts_num' ) ); ?>"><?php _e( 'Number of Posts to Show:', 'featured-custom-post-type-widget-for-genesis' ); ?> </label>
 					<input type="text" id="<?php echo esc_attr( $this->get_field_id( 'posts_num' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'posts_num' ) ); ?>" value="<?php echo esc_attr( $instance['posts_num'] ); ?>" size="2" />
 				</p>
 
 				<p>
-					<label for="<?php echo esc_attr( $this->get_field_id( 'posts_offset' ) ); ?>"><?php _e( 'Number of Posts to Offset:', 'genesis-featured-custom-post-type-widget' ); ?> </label>
+					<label for="<?php echo esc_attr( $this->get_field_id( 'posts_offset' ) ); ?>"><?php _e( 'Number of Posts to Offset:', 'featured-custom-post-type-widget-for-genesis' ); ?> </label>
 					<input type="text" id="<?php echo esc_attr( $this->get_field_id( 'posts_offset' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'posts_offset' ) ); ?>" value="<?php echo esc_attr( $instance['posts_offset'] ); ?>" size="2" />
 				</p>
 
 				<p>
-					<label for="<?php echo esc_attr( $this->get_field_id( 'orderby' ) ); ?>"><?php _e( 'Order By:', 'genesis-featured-custom-post-type-widget' ); ?> </label>
+					<label for="<?php echo esc_attr( $this->get_field_id( 'orderby' ) ); ?>"><?php _e( 'Order By:', 'featured-custom-post-type-widget-for-genesis' ); ?> </label>
 					<select id="<?php echo esc_attr( $this->get_field_id( 'orderby' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'orderby' ) ); ?>">
-						<option value="date" <?php selected( 'date', $instance['orderby'] ); ?>><?php _e( 'Date', 'genesis-featured-custom-post-type-widget' ); ?></option>
-						<option value="title" <?php selected( 'title', $instance['orderby'] ); ?>><?php _e( 'Title', 'genesis-featured-custom-post-type-widget' ); ?></option>
-						<option value="parent" <?php selected( 'parent', $instance['orderby'] ); ?>><?php _e( 'Parent', 'genesis-featured-custom-post-type-widget' ); ?></option>
-						<option value="ID" <?php selected( 'ID', $instance['orderby'] ); ?>><?php _e( 'ID', 'genesis-featured-custom-post-type-widget' ); ?></option>
-						<option value="comment_count" <?php selected( 'comment_count', $instance['orderby'] ); ?>><?php _e( 'Comment Count', 'genesis-featured-custom-post-type-widget' ); ?></option>
-						<option value="rand" <?php selected( 'rand', $instance['orderby'] ); ?>><?php _e( 'Random', 'genesis-featured-custom-post-type-widget' ); ?></option>
+						<option value="date" <?php selected( 'date', $instance['orderby'] ); ?>><?php _e( 'Date', 'featured-custom-post-type-widget-for-genesis' ); ?></option>
+						<option value="title" <?php selected( 'title', $instance['orderby'] ); ?>><?php _e( 'Title', 'featured-custom-post-type-widget-for-genesis' ); ?></option>
+						<option value="parent" <?php selected( 'parent', $instance['orderby'] ); ?>><?php _e( 'Parent', 'featured-custom-post-type-widget-for-genesis' ); ?></option>
+						<option value="ID" <?php selected( 'ID', $instance['orderby'] ); ?>><?php _e( 'ID', 'featured-custom-post-type-widget-for-genesis' ); ?></option>
+						<option value="comment_count" <?php selected( 'comment_count', $instance['orderby'] ); ?>><?php _e( 'Comment Count', 'featured-custom-post-type-widget-for-genesis' ); ?></option>
+						<option value="rand" <?php selected( 'rand', $instance['orderby'] ); ?>><?php _e( 'Random', 'featured-custom-post-type-widget-for-genesis' ); ?></option>
 					</select>
 				</p>
 
 				<p>
-					<label for="<?php echo esc_attr( $this->get_field_id( 'order' ) ); ?>"><?php _e( 'Sort Order:', 'genesis-featured-custom-post-type-widget' ); ?> </label>
+					<label for="<?php echo esc_attr( $this->get_field_id( 'order' ) ); ?>"><?php _e( 'Sort Order:', 'featured-custom-post-type-widget-for-genesis' ); ?> </label>
 					<select id="<?php echo esc_attr( $this->get_field_id( 'order' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'order' ) ); ?>">
-						<option value="DESC" <?php selected( 'DESC', $instance['order'] ); ?>><?php _e( 'Descending (3, 2, 1)', 'genesis-featured-custom-post-type-widget' ); ?></option>
-						<option value="ASC" <?php selected( 'ASC', $instance['order'] ); ?>><?php _e( 'Ascending (1, 2, 3)', 'genesis-featured-custom-post-type-widget' ); ?></option>
+						<option value="DESC" <?php selected( 'DESC', $instance['order'] ); ?>><?php _e( 'Descending (3, 2, 1)', 'featured-custom-post-type-widget-for-genesis' ); ?></option>
+						<option value="ASC" <?php selected( 'ASC', $instance['order'] ); ?>><?php _e( 'Ascending (1, 2, 3)', 'featured-custom-post-type-widget-for-genesis' ); ?></option>
 					</select>
 				</p>
 
 				<p>
 					<input id="<?php echo esc_attr( $this->get_field_id( 'exclude_displayed' ) ); ?>" type="checkbox" name="<?php echo esc_attr( $this->get_field_name( 'exclude_displayed' ) ); ?>" value="1" <?php checked( $instance['exclude_displayed'] ); ?>/>
-					<label for="<?php echo esc_attr( $this->get_field_id( 'exclude_displayed' ) ); ?>"><?php _e( 'Exclude Previously Displayed Posts?', 'genesis-featured-custom-post-type-widget' ); ?></label>
+					<label for="<?php echo esc_attr( $this->get_field_id( 'exclude_displayed' ) ); ?>"><?php _e( 'Exclude Previously Displayed Posts?', 'featured-custom-post-type-widget-for-genesis' ); ?></label>
 				</p>
 
 				<p>
-					<label for="<?php echo esc_attr( $this->get_field_id( 'columns' ) ); ?>"><?php _e( 'Number of Columns:', 'genesis-featured-custom-post-type-widget' ); ?> </label>
+					<label for="<?php echo esc_attr( $this->get_field_id( 'columns' ) ); ?>"><?php _e( 'Number of Columns:', 'featured-custom-post-type-widget-for-genesis' ); ?> </label>
 					<select id="<?php echo esc_attr( $this->get_field_id( 'columns' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'columns' ) ); ?>">
 						<option value="full" <?php selected( 'full', $instance['columns'] ); ?>>1</option>
 						<option value="one_half" <?php selected( 'one_half', $instance['columns'] ); ?>>2</option>
@@ -415,26 +415,26 @@ class Genesis_Featured_Custom_Post_Type extends WP_Widget {
 
 				<p>
 					<input id="<?php echo esc_attr( $this->get_field_id( 'show_gravatar' ) ); ?>" type="checkbox" name="<?php echo esc_attr( $this->get_field_name( 'show_gravatar' ) ); ?>" value="1" <?php checked( $instance['show_gravatar'] ); ?>/>
-					<label for="<?php echo esc_attr( $this->get_field_id( 'show_gravatar' ) ); ?>"><?php _e( 'Show Author Gravatar', 'genesis-featured-custom-post-type-widget' ); ?></label>
+					<label for="<?php echo esc_attr( $this->get_field_id( 'show_gravatar' ) ); ?>"><?php _e( 'Show Author Gravatar', 'featured-custom-post-type-widget-for-genesis' ); ?></label>
 				</p>
 
 				<p>
-					<label for="<?php echo esc_attr( $this->get_field_id( 'gravatar_size' ) ); ?>"><?php _e( 'Gravatar Size:', 'genesis-featured-custom-post-type-widget' ); ?> </label>
+					<label for="<?php echo esc_attr( $this->get_field_id( 'gravatar_size' ) ); ?>"><?php _e( 'Gravatar Size:', 'featured-custom-post-type-widget-for-genesis' ); ?> </label>
 					<select id="<?php echo esc_attr( $this->get_field_id( 'gravatar_size' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'gravatar_size' ) ); ?>">
-						<option value="45" <?php selected( 45, $instance['gravatar_size'] ); ?>><?php _e( 'Small (45px)', 'genesis-featured-custom-post-type-widget' ); ?></option>
-						<option value="65" <?php selected( 65, $instance['gravatar_size'] ); ?>><?php _e( 'Medium (65px)', 'genesis-featured-custom-post-type-widget' ); ?></option>
-						<option value="85" <?php selected( 85, $instance['gravatar_size'] ); ?>><?php _e( 'Large (85px)', 'genesis-featured-custom-post-type-widget' ); ?></option>
-						<option value="125" <?php selected( 105, $instance['gravatar_size'] ); ?>><?php _e( 'Extra Large (125px)', 'genesis-featured-custom-post-type-widget' ); ?></option>
+						<option value="45" <?php selected( 45, $instance['gravatar_size'] ); ?>><?php _e( 'Small (45px)', 'featured-custom-post-type-widget-for-genesis' ); ?></option>
+						<option value="65" <?php selected( 65, $instance['gravatar_size'] ); ?>><?php _e( 'Medium (65px)', 'featured-custom-post-type-widget-for-genesis' ); ?></option>
+						<option value="85" <?php selected( 85, $instance['gravatar_size'] ); ?>><?php _e( 'Large (85px)', 'featured-custom-post-type-widget-for-genesis' ); ?></option>
+						<option value="125" <?php selected( 105, $instance['gravatar_size'] ); ?>><?php _e( 'Extra Large (125px)', 'featured-custom-post-type-widget-for-genesis' ); ?></option>
 					</select>
 				</p>
 
 				<p>
-					<label for="<?php echo esc_attr( $this->get_field_id( 'gravatar_alignment' ) ); ?>"><?php _e( 'Gravatar Alignment:', 'genesis-featured-custom-post-type-widget' ); ?> </label>
+					<label for="<?php echo esc_attr( $this->get_field_id( 'gravatar_alignment' ) ); ?>"><?php _e( 'Gravatar Alignment:', 'featured-custom-post-type-widget-for-genesis' ); ?> </label>
 					<select id="<?php echo esc_attr( $this->get_field_id( 'gravatar_alignment' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'gravatar_alignment' ) ); ?>">
-						<option value="alignnone">- <?php _e( 'None', 'genesis-featured-custom-post-type-widget' ); ?> -</option>
-						<option value="alignleft" <?php selected( 'alignleft', $instance['gravatar_alignment'] ); ?>><?php _e( 'Left', 'genesis-featured-custom-post-type-widget' ); ?></option>
-						<option value="alignright" <?php selected( 'alignright', $instance['gravatar_alignment'] ); ?>><?php _e( 'Right', 'genesis-featured-custom-post-type-widget' ); ?></option>
-						<option value="aligncenter" <?php selected( 'aligncenter', $instance['gravatar_alignment'] ); ?>><?php _e( 'Center', 'genesis-featured-custom-post-type-widget' ); ?></option>
+						<option value="alignnone">- <?php _e( 'None', 'featured-custom-post-type-widget-for-genesis' ); ?> -</option>
+						<option value="alignleft" <?php selected( 'alignleft', $instance['gravatar_alignment'] ); ?>><?php _e( 'Left', 'featured-custom-post-type-widget-for-genesis' ); ?></option>
+						<option value="alignright" <?php selected( 'alignright', $instance['gravatar_alignment'] ); ?>><?php _e( 'Right', 'featured-custom-post-type-widget-for-genesis' ); ?></option>
+						<option value="aligncenter" <?php selected( 'aligncenter', $instance['gravatar_alignment'] ); ?>><?php _e( 'Center', 'featured-custom-post-type-widget-for-genesis' ); ?></option>
 					</select>
 				</p>
 
@@ -444,11 +444,11 @@ class Genesis_Featured_Custom_Post_Type extends WP_Widget {
 
 				<p>
 					<input id="<?php echo esc_attr( $this->get_field_id( 'show_image' ) ); ?>" type="checkbox" name="<?php echo esc_attr( $this->get_field_name( 'show_image' ) ); ?>" value="1" <?php checked( $instance['show_image'] ); ?>/>
-					<label for="<?php echo esc_attr( $this->get_field_id( 'show_image' ) ); ?>"><?php _e( 'Show Featured Image', 'genesis-featured-custom-post-type-widget' ); ?></label>
+					<label for="<?php echo esc_attr( $this->get_field_id( 'show_image' ) ); ?>"><?php _e( 'Show Featured Image', 'featured-custom-post-type-widget-for-genesis' ); ?></label>
 				</p>
 
 				<p>
-					<label for="<?php echo esc_attr( $this->get_field_id( 'image_size' ) ); ?>"><?php _e( 'Image Size:', 'genesis-featured-custom-post-type-widget' ); ?> </label>
+					<label for="<?php echo esc_attr( $this->get_field_id( 'image_size' ) ); ?>"><?php _e( 'Image Size:', 'featured-custom-post-type-widget-for-genesis' ); ?> </label>
 					<select id="<?php echo esc_attr( $this->get_field_id( 'image_size' ) ); ?>" class="genesis-image-size-selector" name="<?php echo esc_attr( $this->get_field_name( 'image_size' ) ); ?>">
 						<?php
 						$sizes = genesis_get_image_sizes();
@@ -459,12 +459,12 @@ class Genesis_Featured_Custom_Post_Type extends WP_Widget {
 				</p>
 
 				<p>
-					<label for="<?php echo esc_attr( $this->get_field_id( 'image_alignment' ) ); ?>"><?php _e( 'Image Alignment:', 'genesis-featured-custom-post-type-widget' ); ?> </label>
+					<label for="<?php echo esc_attr( $this->get_field_id( 'image_alignment' ) ); ?>"><?php _e( 'Image Alignment:', 'featured-custom-post-type-widget-for-genesis' ); ?> </label>
 					<select id="<?php echo esc_attr( $this->get_field_id( 'image_alignment' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'image_alignment' ) ); ?>">
-						<option value="alignnone">- <?php _e( 'None', 'genesis-featured-custom-post-type-widget' ); ?> -</option>
-						<option value="alignleft" <?php selected( 'alignleft', $instance['image_alignment'] ); ?>><?php _e( 'Left', 'genesis-featured-custom-post-type-widget' ); ?></option>
-						<option value="alignright" <?php selected( 'alignright', $instance['image_alignment'] ); ?>><?php _e( 'Right', 'genesis-featured-custom-post-type-widget' ); ?></option>
-						<option value="aligncenter" <?php selected( 'aligncenter', $instance['image_alignment'] ); ?>><?php _e( 'Center', 'genesis-featured-custom-post-type-widget' ); ?></option>
+						<option value="alignnone">- <?php _e( 'None', 'featured-custom-post-type-widget-for-genesis' ); ?> -</option>
+						<option value="alignleft" <?php selected( 'alignleft', $instance['image_alignment'] ); ?>><?php _e( 'Left', 'featured-custom-post-type-widget-for-genesis' ); ?></option>
+						<option value="alignright" <?php selected( 'alignright', $instance['image_alignment'] ); ?>><?php _e( 'Right', 'featured-custom-post-type-widget-for-genesis' ); ?></option>
+						<option value="aligncenter" <?php selected( 'aligncenter', $instance['image_alignment'] ); ?>><?php _e( 'Center', 'featured-custom-post-type-widget-for-genesis' ); ?></option>
 					</select>
 				</p>
 
@@ -478,32 +478,32 @@ class Genesis_Featured_Custom_Post_Type extends WP_Widget {
 
 				<p>
 					<input id="<?php echo esc_attr( $this->get_field_id( 'show_title' ) ); ?>" type="checkbox" name="<?php echo esc_attr( $this->get_field_name( 'show_title' ) ); ?>" value="1" <?php checked( $instance['show_title'] ); ?>/>
-					<label for="<?php echo esc_attr( $this->get_field_id( 'show_title' ) ); ?>"><?php _e( 'Show Post Title', 'genesis-featured-custom-post-type-widget' ); ?></label>
+					<label for="<?php echo esc_attr( $this->get_field_id( 'show_title' ) ); ?>"><?php _e( 'Show Post Title', 'featured-custom-post-type-widget-for-genesis' ); ?></label>
 				</p>
 
 				<p>
 					<input id="<?php echo esc_attr( $this->get_field_id( 'show_byline' ) ); ?>" type="checkbox" name="<?php echo esc_attr( $this->get_field_name( 'show_byline' ) ); ?>" value="1" <?php checked( $instance['show_byline'] ); ?>/>
-					<label for="<?php echo esc_attr( $this->get_field_id( 'show_byline' ) ); ?>"><?php _e( 'Show Post Info', 'genesis-featured-custom-post-type-widget' ); ?></label>
+					<label for="<?php echo esc_attr( $this->get_field_id( 'show_byline' ) ); ?>"><?php _e( 'Show Post Info', 'featured-custom-post-type-widget-for-genesis' ); ?></label>
 					<input type="text" id="<?php echo esc_attr( $this->get_field_id( 'post_info' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'post_info' ) ); ?>" value="<?php echo esc_attr( $instance['post_info'] ); ?>" class="widefat" />
 				</p>
 
 				<p>
-					<label for="<?php echo esc_attr( $this->get_field_id( 'show_content' ) ); ?>"><?php _e( 'Content Type:', 'genesis-featured-custom-post-type-widget' ); ?> </label>
+					<label for="<?php echo esc_attr( $this->get_field_id( 'show_content' ) ); ?>"><?php _e( 'Content Type:', 'featured-custom-post-type-widget-for-genesis' ); ?> </label>
 					<select id="<?php echo esc_attr( $this->get_field_id( 'show_content' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'show_content' ) ); ?>">
-						<option value="content" <?php selected( 'content', $instance['show_content'] ); ?>><?php _e( 'Show Content', 'genesis-featured-custom-post-type-widget' ); ?></option>
-						<option value="excerpt" <?php selected( 'excerpt', $instance['show_content'] ); ?>><?php _e( 'Show Excerpt', 'genesis-featured-custom-post-type-widget' ); ?></option>
-						<option value="content-limit" <?php selected( 'content-limit', $instance['show_content'] ); ?>><?php _e( 'Show Content Limit', 'genesis-featured-custom-post-type-widget' ); ?></option>
-						<option value="" <?php selected( '', $instance['show_content'] ); ?>><?php _e( 'No Content', 'genesis-featured-custom-post-type-widget' ); ?></option>
+						<option value="content" <?php selected( 'content', $instance['show_content'] ); ?>><?php _e( 'Show Content', 'featured-custom-post-type-widget-for-genesis' ); ?></option>
+						<option value="excerpt" <?php selected( 'excerpt', $instance['show_content'] ); ?>><?php _e( 'Show Excerpt', 'featured-custom-post-type-widget-for-genesis' ); ?></option>
+						<option value="content-limit" <?php selected( 'content-limit', $instance['show_content'] ); ?>><?php _e( 'Show Content Limit', 'featured-custom-post-type-widget-for-genesis' ); ?></option>
+						<option value="" <?php selected( '', $instance['show_content'] ); ?>><?php _e( 'No Content', 'featured-custom-post-type-widget-for-genesis' ); ?></option>
 					</select>
 					<br />
-					<label for="<?php echo esc_attr( $this->get_field_id( 'content_limit' ) ); ?>"><?php _e( 'Limit content to', 'genesis-featured-custom-post-type-widget' ); ?>
+					<label for="<?php echo esc_attr( $this->get_field_id( 'content_limit' ) ); ?>"><?php _e( 'Limit content to', 'featured-custom-post-type-widget-for-genesis' ); ?>
 						<input type="text" id="<?php echo esc_attr( $this->get_field_id( 'image_alignment' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'content_limit' ) ); ?>" value="<?php echo esc_attr( intval( $instance['content_limit'] ) ); ?>" size="3" />
-						<?php _e( 'characters', 'genesis-featured-custom-post-type-widget' ); ?>
+						<?php _e( 'characters', 'featured-custom-post-type-widget-for-genesis' ); ?>
 					</label>
 				</p>
 
 				<p>
-					<label for="<?php echo esc_attr( $this->get_field_id( 'more_text' ) ); ?>"><?php _e( 'More Text (if applicable):', 'genesis-featured-custom-post-type-widget' ); ?> </label>
+					<label for="<?php echo esc_attr( $this->get_field_id( 'more_text' ) ); ?>"><?php _e( 'More Text (if applicable):', 'featured-custom-post-type-widget-for-genesis' ); ?> </label>
 					<input type="text" id="<?php echo esc_attr( $this->get_field_id( 'more_text' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'more_text' ) ); ?>" value="<?php echo esc_attr( $instance['more_text'] ); ?>" />
 				</p>
 
@@ -511,15 +511,15 @@ class Genesis_Featured_Custom_Post_Type extends WP_Widget {
 
 			<div class="genesis-widget-column-box">
 
-				<p><?php _e( 'To display an unordered list of more posts from this category, please fill out the information below', 'genesis-featured-custom-post-type-widget' ); ?>:</p>
+				<p><?php _e( 'To display an unordered list of more posts from this category, please fill out the information below', 'featured-custom-post-type-widget-for-genesis' ); ?>:</p>
 
 				<p>
-					<label for="<?php echo esc_attr( $this->get_field_id( 'extra_title' ) ); ?>"><?php _e( 'Title:', 'genesis-featured-custom-post-type-widget' ); ?> </label>
+					<label for="<?php echo esc_attr( $this->get_field_id( 'extra_title' ) ); ?>"><?php _e( 'Title:', 'featured-custom-post-type-widget-for-genesis' ); ?> </label>
 					<input type="text" id="<?php echo esc_attr( $this->get_field_id( 'extra_title' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'extra_title' ) ); ?>" value="<?php echo esc_attr( $instance['extra_title'] ); ?>" class="widefat" />
 				</p>
 
 				<p>
-					<label for="<?php echo esc_attr( $this->get_field_id( 'extra_num' ) ); ?>"><?php _e( 'Number of Posts to Show:', 'genesis-featured-custom-post-type-widget' ); ?> </label>
+					<label for="<?php echo esc_attr( $this->get_field_id( 'extra_num' ) ); ?>"><?php _e( 'Number of Posts to Show:', 'featured-custom-post-type-widget-for-genesis' ); ?> </label>
 					<input type="text" id="<?php echo esc_attr( $this->get_field_id( 'extra_num' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'extra_num' ) ); ?>" value="<?php echo esc_attr( $instance['extra_num'] ); ?>" size="2" />
 				</p>
 
@@ -529,20 +529,20 @@ class Genesis_Featured_Custom_Post_Type extends WP_Widget {
 
 				<p>
 					<input id="<?php echo esc_attr( $this->get_field_id( 'more_from_category' ) ); ?>" type="checkbox" name="<?php echo esc_attr( $this->get_field_name( 'more_from_category' ) ); ?>" value="1" <?php checked( $instance['more_from_category'] ); ?>/>
-					<label for="<?php echo esc_attr( $this->get_field_id( 'more_from_category' ) ); ?>"><?php _e( 'Show Category Archive Link', 'genesis-featured-custom-post-type-widget' ); ?></label>
+					<label for="<?php echo esc_attr( $this->get_field_id( 'more_from_category' ) ); ?>"><?php _e( 'Show Category Archive Link', 'featured-custom-post-type-widget-for-genesis' ); ?></label>
 				</p>
 
 				<p>
-					<label for="<?php echo esc_attr( $this->get_field_id( 'more_from_category_text' ) ); ?>"><?php _e( 'Link Text:', 'genesis-featured-custom-post-type-widget' ); ?> </label>
+					<label for="<?php echo esc_attr( $this->get_field_id( 'more_from_category_text' ) ); ?>"><?php _e( 'Link Text:', 'featured-custom-post-type-widget-for-genesis' ); ?> </label>
 					<input type="text" id="<?php echo esc_attr( $this->get_field_id( 'more_from_category_text' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'more_from_category_text' ) ); ?>" value="<?php echo esc_attr( $instance['more_from_category_text'] ); ?>" class="widefat" />
 				</p>
 
 				<p>
 					<input id="<?php echo esc_attr( $this->get_field_id( 'archive_link' ) ); ?>" type="checkbox" name="<?php echo esc_attr( $this->get_field_name( 'archive_link' ) ); ?>" value="1" <?php checked( $instance['archive_link'] ); ?>/>
-					<label for="<?php echo esc_attr( $this->get_field_id( 'archive_link' ) ); ?>"><?php _e( 'Show Archive Link', 'genesis-featured-custom-post-type-widget' ); ?></label>
+					<label for="<?php echo esc_attr( $this->get_field_id( 'archive_link' ) ); ?>"><?php _e( 'Show Archive Link', 'featured-custom-post-type-widget-for-genesis' ); ?></label>
 				</p>
 				<p>
-					<label for="<?php echo esc_attr( $this->get_field_id( 'archive_text' ) ); ?>"><?php _e( 'Link Text:', 'genesis-featured-custom-post-type-widget' ); ?> </label>
+					<label for="<?php echo esc_attr( $this->get_field_id( 'archive_text' ) ); ?>"><?php _e( 'Link Text:', 'featured-custom-post-type-widget-for-genesis' ); ?> </label>
 					<input type="text" id="<?php echo esc_attr( $this->get_field_id( 'archive_text' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'archive_text' ) ); ?>" value="<?php echo esc_attr( $instance['archive_text'] ); ?>" class="widefat" />
 				</p>
 
@@ -700,7 +700,7 @@ class Genesis_Featured_Custom_Post_Type extends WP_Widget {
 	/**
 	 * Set up a grid of one-half elements for use in a post_class filter.
 	 *
-	 * @since      x.y.z
+	 * @since      2.0.0
 	 * @category   Grid Loop
 	 * @param      $classes array An array of the current post classes
 	 * @return     $classes array The current post classes with the grid appended
@@ -713,7 +713,7 @@ class Genesis_Featured_Custom_Post_Type extends WP_Widget {
 	/**
 	 * Set up a grid of one-third elements for use in a post_class filter.
 	 *
-	 * @since      x.y.z
+	 * @since      2.0.0
 	 * @category   Grid Loop
 	 * @param      $classes array An array of the current post classes
 	 * @return     $classes array The current post classes with the grid appended
@@ -726,7 +726,7 @@ class Genesis_Featured_Custom_Post_Type extends WP_Widget {
 	/**
 	 * Set up a grid of one-fourth elements for use in a post_class filter.
 	 *
-	 * @since      x.y.z
+	 * @since      2.0.0
 	 * @category   Grid Loop
 	 * @param      $classes array An array of the current post classes
 	 * @return     $classes array The current post classes with the grid appended
@@ -739,7 +739,7 @@ class Genesis_Featured_Custom_Post_Type extends WP_Widget {
 	/**
 	 * Set up a grid of one-sixth elements for use in a post_class filter.
 	 *
-	 * @since      x.y.z
+	 * @since      2.0.0
 	 * @category   Grid Loop
 	 * @param      $classes array An array of the current post classes
 	 * @return     $classes array The current post classes with the grid appended

--- a/includes/class-featured-custom-post-type-widget-registrations.php
+++ b/includes/class-featured-custom-post-type-widget-registrations.php
@@ -595,7 +595,7 @@ class Genesis_Featured_Custom_Post_Type extends WP_Widget {
 	 */
 	function admin_enqueue() {
 		$screen = get_current_screen()->id;
-		if ( $screen === 'widgets' || $screen === 'customize' ) {
+		if ( in_array( $screen, array( 'widgets', 'customize' ) ) ) {
 			wp_enqueue_script( 'tax-term-ajax-script', plugins_url( '/ajax_handler.js', __FILE__ ), array('jquery') );
 			wp_localize_script( 'tax-term-ajax-script', 'ajax_object', array( 'ajax_url' => admin_url( 'admin-ajax.php' ) ) );
 		}

--- a/includes/class-featured-custom-post-type-widget-registrations.php
+++ b/includes/class-featured-custom-post-type-widget-registrations.php
@@ -651,6 +651,7 @@ class Genesis_Featured_Custom_Post_Type extends WP_Widget {
 		);
 
 		//* Add the appropriate column class.
+		$classes[] = 'grid';
 		$classes[] = $column_classes[absint($columns)];
 
 		//* Add an "odd" class to allow for more control of grid clollapse.

--- a/includes/class-featured-custom-post-type-widget-registrations.php
+++ b/includes/class-featured-custom-post-type-widget-registrations.php
@@ -424,7 +424,7 @@ class Genesis_Featured_Custom_Post_Type extends WP_Widget {
 						<option value="45" <?php selected( 45, $instance['gravatar_size'] ); ?>><?php _e( 'Small (45px)', 'featured-custom-post-type-widget-for-genesis' ); ?></option>
 						<option value="65" <?php selected( 65, $instance['gravatar_size'] ); ?>><?php _e( 'Medium (65px)', 'featured-custom-post-type-widget-for-genesis' ); ?></option>
 						<option value="85" <?php selected( 85, $instance['gravatar_size'] ); ?>><?php _e( 'Large (85px)', 'featured-custom-post-type-widget-for-genesis' ); ?></option>
-						<option value="125" <?php selected( 105, $instance['gravatar_size'] ); ?>><?php _e( 'Extra Large (125px)', 'featured-custom-post-type-widget-for-genesis' ); ?></option>
+						<option value="125" <?php selected( 125, $instance['gravatar_size'] ); ?>><?php _e( 'Extra Large (125px)', 'featured-custom-post-type-widget-for-genesis' ); ?></option>
 					</select>
 				</p>
 

--- a/includes/class-featured-custom-post-type-widget-registrations.php
+++ b/includes/class-featured-custom-post-type-widget-registrations.php
@@ -376,13 +376,13 @@ class Genesis_Featured_Custom_Post_Type extends WP_Widget {
 					<select id="<?php echo $this->get_field_id( 'tax_term' ); ?>" name="<?php echo $this->get_field_name( 'tax_term' ); ?>">
 
 						<?php
+						echo '<option style="padding-right:10px;" value="any" '. selected( 'any', $instance['tax_term'], false ) .'>'. __( 'any', 'genesis-featured-custom-post-type-widget' ) .'</option>';
 						foreach ( $tax_term_list as $tax_term_item ) {
 							$tax_term_desc = $tax_term_item->taxonomy . '/' . $tax_term_item->name;
 							$tax_term_slug = $tax_term_item->taxonomy . '/' . $tax_term_item->slug;
 							echo '<option style="padding-right:10px;" value="'. esc_attr( $tax_term_slug ) .'" '. selected( esc_attr( $tax_term_slug ), $instance['tax_term'], false ) .'>'. esc_attr( $tax_term_desc ) .'</option>';
 						}
 
-						echo '<option style="padding-right:10px;" value="any" '. selected( 'any', $instance['tax_term'], false ) .'>'. __( 'any', 'genesis-featured-custom-post-type-widget' ) .'</option>';
 						?>
 					</select>
 				</p>
@@ -622,11 +622,11 @@ class Genesis_Featured_Custom_Post_Type extends WP_Widget {
 		$tax_term_list = get_terms( $taxonomies, $tax_args );
 
 		// Build an appropriate JSON response containing this info
+		$taxes['any'] = 'any';
 		foreach ( $tax_term_list as $tax_term_item ) {
 			$taxes [$tax_term_item->taxonomy . '/' . $tax_term_item->slug] =
 				$tax_term_item->taxonomy . '/' . $tax_term_item->name;
 		}
-		$taxes['any'] = 'any';
 
 		// And emit it
 		echo json_encode( $taxes );

--- a/includes/class-featured-custom-post-type-widget-registrations.php
+++ b/includes/class-featured-custom-post-type-widget-registrations.php
@@ -325,8 +325,8 @@ class Genesis_Featured_Custom_Post_Type extends WP_Widget {
 
 		?>
 		<p>
-			<label for="<?php echo $this->get_field_id( 'title' ); ?>"><?php _e( 'Title', 'genesis-featured-custom-post-type-widget' ); ?>:</label>
-			<input type="text" id="<?php echo $this->get_field_id( 'title' ); ?>" name="<?php echo $this->get_field_name( 'title' ); ?>" value="<?php echo esc_attr( $instance['title'] ); ?>" class="widefat" />
+			<label for="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>"><?php _e( 'Title:', 'genesis-featured-custom-post-type-widget' ); ?> </label>
+			<input type="text" id="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'title' ) ); ?>" value="<?php echo esc_attr( $instance['title'] ); ?>" class="widefat" />
 		</p>
 
 		<div class="genesis-widget-column">
@@ -334,13 +334,13 @@ class Genesis_Featured_Custom_Post_Type extends WP_Widget {
 			<div class="genesis-widget-column-box genesis-widget-column-box-top">
 
 				<p>
-					<label for="<?php echo $this->get_field_id( 'post_type' ); ?>"><?php _e( 'Post Type', 'genesis-featured-custom-post-type-widget' ); ?>:</label>
-					<select id="<?php echo $this->get_field_id( 'post_type' ); ?>" name="<?php echo $this->get_field_name( 'post_type' ); ?>" onchange="tax_term_postback('<?php echo $this->get_field_id( 'tax_term' ); ?>', this.value);" >
+					<label for="<?php echo esc_attr( $this->get_field_id( 'post_type' ) ); ?>"><?php _e( 'Post Type:', 'genesis-featured-custom-post-type-widget' ); ?> </label>
+					<select id="<?php echo esc_attr( $this->get_field_id( 'post_type' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'post_type' ) ); ?>" onchange="tax_term_postback('<?php echo esc_attr( $this->get_field_id( 'tax_term' ) ); ?>', this.value);" >
 
 						<?php
 						echo '<option value="any" '. selected( 'any', $instance['post_type'], false ) .'>'. __( 'any', 'genesis-featured-custom-post-type-widget' ) .'</option>';
 						foreach ( $item->post_type_list as $post_type_item ) {
-							echo '<option value="'. esc_attr( $post_type_item ) .'" '. selected( esc_attr( $post_type_item ), $instance['post_type'], false ) .'>'. esc_attr( $post_type_item ) .'</option>';
+							echo '<option value="'. esc_attr( $post_type_item ) .'"'. selected( esc_attr( $post_type_item ), $instance['post_type'], false ) .'>'. esc_attr( $post_type_item ) .'</option>';
 						}
 
 						?>
@@ -348,15 +348,15 @@ class Genesis_Featured_Custom_Post_Type extends WP_Widget {
 				</p>
 
 				<p>
-					<label for="<?php echo $this->get_field_id( 'tax_term' ); ?>"><?php _e( 'Category/Term', 'genesis-featured-custom-post-type-widget' ); ?>:</label>
-					<select id="<?php echo $this->get_field_id( 'tax_term' ); ?>" name="<?php echo $this->get_field_name( 'tax_term' ); ?>">
+					<label for="<?php echo esc_attr( $this->get_field_id( 'tax_term' ) ); ?>"><?php _e( 'Category/Term:', 'genesis-featured-custom-post-type-widget' ); ?> </label>
+					<select id="<?php echo esc_attr( $this->get_field_id( 'tax_term' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'tax_term' ) ); ?>">
 
 						<?php
 						echo '<option value="any" '. selected( 'any', $instance['tax_term'], false ) .'>'. __( 'any', 'genesis-featured-custom-post-type-widget' ) .'</option>';
 						foreach ( $item->tax_term_list as $tax_term_item ) {
 							$tax_term_desc = $tax_term_item->taxonomy . '/' . $tax_term_item->name;
 							$tax_term_slug = $tax_term_item->taxonomy . '/' . $tax_term_item->slug;
-							echo '<option value="'. esc_attr( $tax_term_slug ) .'" '. selected( esc_attr( $tax_term_slug ), $instance['tax_term'], false ) .'>'. esc_attr( $tax_term_desc ) .'</option>';
+							echo '<option value="'. esc_attr( $tax_term_slug ) .'"'. selected( esc_attr( $tax_term_slug ), $instance['tax_term'], false ) .'>'. esc_attr( $tax_term_desc ) .'</option>';
 						}
 
 						?>
@@ -364,18 +364,18 @@ class Genesis_Featured_Custom_Post_Type extends WP_Widget {
 				</p>
 
 				<p>
-					<label for="<?php echo $this->get_field_id( 'posts_num' ); ?>"><?php _e( 'Number of Posts to Show', 'genesis-featured-custom-post-type-widget' ); ?>:</label>
-					<input type="text" id="<?php echo $this->get_field_id( 'posts_num' ); ?>" name="<?php echo $this->get_field_name( 'posts_num' ); ?>" value="<?php echo esc_attr( $instance['posts_num'] ); ?>" size="2" />
+					<label for="<?php echo esc_attr( $this->get_field_id( 'posts_num' ) ); ?>"><?php _e( 'Number of Posts to Show:', 'genesis-featured-custom-post-type-widget' ); ?> </label>
+					<input type="text" id="<?php echo esc_attr( $this->get_field_id( 'posts_num' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'posts_num' ) ); ?>" value="<?php echo esc_attr( $instance['posts_num'] ); ?>" size="2" />
 				</p>
 
 				<p>
-					<label for="<?php echo $this->get_field_id( 'posts_offset' ); ?>"><?php _e( 'Number of Posts to Offset', 'genesis-featured-custom-post-type-widget' ); ?>:</label>
-					<input type="text" id="<?php echo $this->get_field_id( 'posts_offset' ); ?>" name="<?php echo $this->get_field_name( 'posts_offset' ); ?>" value="<?php echo esc_attr( $instance['posts_offset'] ); ?>" size="2" />
+					<label for="<?php echo esc_attr( $this->get_field_id( 'posts_offset' ) ); ?>"><?php _e( 'Number of Posts to Offset:', 'genesis-featured-custom-post-type-widget' ); ?> </label>
+					<input type="text" id="<?php echo esc_attr( $this->get_field_id( 'posts_offset' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'posts_offset' ) ); ?>" value="<?php echo esc_attr( $instance['posts_offset'] ); ?>" size="2" />
 				</p>
 
 				<p>
-					<label for="<?php echo $this->get_field_id( 'orderby' ); ?>"><?php _e( 'Order By', 'genesis-featured-custom-post-type-widget' ); ?>:</label>
-					<select id="<?php echo $this->get_field_id( 'orderby' ); ?>" name="<?php echo $this->get_field_name( 'orderby' ); ?>">
+					<label for="<?php echo esc_attr( $this->get_field_id( 'orderby' ) ); ?>"><?php _e( 'Order By:', 'genesis-featured-custom-post-type-widget' ); ?> </label>
+					<select id="<?php echo esc_attr( $this->get_field_id( 'orderby' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'orderby' ) ); ?>">
 						<option value="date" <?php selected( 'date', $instance['orderby'] ); ?>><?php _e( 'Date', 'genesis-featured-custom-post-type-widget' ); ?></option>
 						<option value="title" <?php selected( 'title', $instance['orderby'] ); ?>><?php _e( 'Title', 'genesis-featured-custom-post-type-widget' ); ?></option>
 						<option value="parent" <?php selected( 'parent', $instance['orderby'] ); ?>><?php _e( 'Parent', 'genesis-featured-custom-post-type-widget' ); ?></option>
@@ -386,21 +386,21 @@ class Genesis_Featured_Custom_Post_Type extends WP_Widget {
 				</p>
 
 				<p>
-					<label for="<?php echo $this->get_field_id( 'order' ); ?>"><?php _e( 'Sort Order', 'genesis-featured-custom-post-type-widget' ); ?>:</label>
-					<select id="<?php echo $this->get_field_id( 'order' ); ?>" name="<?php echo $this->get_field_name( 'order' ); ?>">
+					<label for="<?php echo esc_attr( $this->get_field_id( 'order' ) ); ?>"><?php _e( 'Sort Order:', 'genesis-featured-custom-post-type-widget' ); ?> </label>
+					<select id="<?php echo esc_attr( $this->get_field_id( 'order' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'order' ) ); ?>">
 						<option value="DESC" <?php selected( 'DESC', $instance['order'] ); ?>><?php _e( 'Descending (3, 2, 1)', 'genesis-featured-custom-post-type-widget' ); ?></option>
 						<option value="ASC" <?php selected( 'ASC', $instance['order'] ); ?>><?php _e( 'Ascending (1, 2, 3)', 'genesis-featured-custom-post-type-widget' ); ?></option>
 					</select>
 				</p>
 
 				<p>
-					<input id="<?php echo $this->get_field_id( 'exclude_displayed' ); ?>" type="checkbox" name="<?php echo $this->get_field_name( 'exclude_displayed' ); ?>" value="1" <?php checked( $instance['exclude_displayed'] ); ?>/>
-					<label for="<?php echo $this->get_field_id( 'exclude_displayed' ); ?>"><?php _e( 'Exclude Previously Displayed Posts?', 'genesis-featured-custom-post-type-widget' ); ?></label>
+					<input id="<?php echo esc_attr( $this->get_field_id( 'exclude_displayed' ) ); ?>" type="checkbox" name="<?php echo esc_attr( $this->get_field_name( 'exclude_displayed' ) ); ?>" value="1" <?php checked( $instance['exclude_displayed'] ); ?>/>
+					<label for="<?php echo esc_attr( $this->get_field_id( 'exclude_displayed' ) ); ?>"><?php _e( 'Exclude Previously Displayed Posts?', 'genesis-featured-custom-post-type-widget' ); ?></label>
 				</p>
 
 				<p>
-					<label for="<?php echo $this->get_field_id( 'columns' ); ?>"><?php _e( 'Number of Columns', 'sawrie-cpt' ); ?>:</label>
-					<select id="<?php echo $this->get_field_id( 'columns' ); ?>" name="<?php echo $this->get_field_name( 'columns' ); ?>">
+					<label for="<?php echo esc_attr( $this->get_field_id( 'columns' ) ); ?>"><?php _e( 'Number of Columns:', 'genesis-featured-custom-post-type-widget' ); ?> </label>
+					<select id="<?php echo esc_attr( $this->get_field_id( 'columns' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'columns' ) ); ?>">
 						<option value="full" <?php selected( 'full', $instance['columns'] ); ?>>1</option>
 						<option value="one_half" <?php selected( 'one_half', $instance['columns'] ); ?>>2</option>
 						<option value="one_third" <?php selected( 'one_third', $instance['columns'] ); ?>>3</option>
@@ -414,13 +414,13 @@ class Genesis_Featured_Custom_Post_Type extends WP_Widget {
 			<div class="genesis-widget-column-box">
 
 				<p>
-					<input id="<?php echo $this->get_field_id( 'show_gravatar' ); ?>" type="checkbox" name="<?php echo $this->get_field_name( 'show_gravatar' ); ?>" value="1" <?php checked( $instance['show_gravatar'] ); ?>/>
-					<label for="<?php echo $this->get_field_id( 'show_gravatar' ); ?>"><?php _e( 'Show Author Gravatar', 'genesis-featured-custom-post-type-widget' ); ?></label>
+					<input id="<?php echo esc_attr( $this->get_field_id( 'show_gravatar' ) ); ?>" type="checkbox" name="<?php echo esc_attr( $this->get_field_name( 'show_gravatar' ) ); ?>" value="1" <?php checked( $instance['show_gravatar'] ); ?>/>
+					<label for="<?php echo esc_attr( $this->get_field_id( 'show_gravatar' ) ); ?>"><?php _e( 'Show Author Gravatar', 'genesis-featured-custom-post-type-widget' ); ?></label>
 				</p>
 
 				<p>
-					<label for="<?php echo $this->get_field_id( 'gravatar_size' ); ?>"><?php _e( 'Gravatar Size', 'genesis-featured-custom-post-type-widget' ); ?>:</label>
-					<select id="<?php echo $this->get_field_id( 'gravatar_size' ); ?>" name="<?php echo $this->get_field_name( 'gravatar_size' ); ?>">
+					<label for="<?php echo esc_attr( $this->get_field_id( 'gravatar_size' ) ); ?>"><?php _e( 'Gravatar Size:', 'genesis-featured-custom-post-type-widget' ); ?> </label>
+					<select id="<?php echo esc_attr( $this->get_field_id( 'gravatar_size' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'gravatar_size' ) ); ?>">
 						<option value="45" <?php selected( 45, $instance['gravatar_size'] ); ?>><?php _e( 'Small (45px)', 'genesis-featured-custom-post-type-widget' ); ?></option>
 						<option value="65" <?php selected( 65, $instance['gravatar_size'] ); ?>><?php _e( 'Medium (65px)', 'genesis-featured-custom-post-type-widget' ); ?></option>
 						<option value="85" <?php selected( 85, $instance['gravatar_size'] ); ?>><?php _e( 'Large (85px)', 'genesis-featured-custom-post-type-widget' ); ?></option>
@@ -429,8 +429,8 @@ class Genesis_Featured_Custom_Post_Type extends WP_Widget {
 				</p>
 
 				<p>
-					<label for="<?php echo $this->get_field_id( 'gravatar_alignment' ); ?>"><?php _e( 'Gravatar Alignment', 'genesis-featured-custom-post-type-widget' ); ?>:</label>
-					<select id="<?php echo $this->get_field_id( 'gravatar_alignment' ); ?>" name="<?php echo $this->get_field_name( 'gravatar_alignment' ); ?>">
+					<label for="<?php echo esc_attr( $this->get_field_id( 'gravatar_alignment' ) ); ?>"><?php _e( 'Gravatar Alignment:', 'genesis-featured-custom-post-type-widget' ); ?> </label>
+					<select id="<?php echo esc_attr( $this->get_field_id( 'gravatar_alignment' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'gravatar_alignment' ) ); ?>">
 						<option value="alignnone">- <?php _e( 'None', 'genesis-featured-custom-post-type-widget' ); ?> -</option>
 						<option value="alignleft" <?php selected( 'alignleft', $instance['gravatar_alignment'] ); ?>><?php _e( 'Left', 'genesis-featured-custom-post-type-widget' ); ?></option>
 						<option value="alignright" <?php selected( 'alignright', $instance['gravatar_alignment'] ); ?>><?php _e( 'Right', 'genesis-featured-custom-post-type-widget' ); ?></option>
@@ -443,24 +443,24 @@ class Genesis_Featured_Custom_Post_Type extends WP_Widget {
 			<div class="genesis-widget-column-box">
 
 				<p>
-					<input id="<?php echo $this->get_field_id( 'show_image' ); ?>" type="checkbox" name="<?php echo $this->get_field_name( 'show_image' ); ?>" value="1" <?php checked( $instance['show_image'] ); ?>/>
-					<label for="<?php echo $this->get_field_id( 'show_image' ); ?>"><?php _e( 'Show Featured Image', 'genesis-featured-custom-post-type-widget' ); ?></label>
+					<input id="<?php echo esc_attr( $this->get_field_id( 'show_image' ) ); ?>" type="checkbox" name="<?php echo esc_attr( $this->get_field_name( 'show_image' ) ); ?>" value="1" <?php checked( $instance['show_image'] ); ?>/>
+					<label for="<?php echo esc_attr( $this->get_field_id( 'show_image' ) ); ?>"><?php _e( 'Show Featured Image', 'genesis-featured-custom-post-type-widget' ); ?></label>
 				</p>
 
 				<p>
-					<label for="<?php echo $this->get_field_id( 'image_size' ); ?>"><?php _e( 'Image Size', 'genesis-featured-custom-post-type-widget' ); ?>:</label>
-					<select id="<?php echo $this->get_field_id( 'image_size' ); ?>" class="genesis-image-size-selector" name="<?php echo $this->get_field_name( 'image_size' ); ?>">
+					<label for="<?php echo esc_attr( $this->get_field_id( 'image_size' ) ); ?>"><?php _e( 'Image Size:', 'genesis-featured-custom-post-type-widget' ); ?> </label>
+					<select id="<?php echo esc_attr( $this->get_field_id( 'image_size' ) ); ?>" class="genesis-image-size-selector" name="<?php echo esc_attr( $this->get_field_name( 'image_size' ) ); ?>">
 						<?php
 						$sizes = genesis_get_image_sizes();
 						foreach( (array) $sizes as $name => $size )
-							echo '<option value="'.esc_attr( $name ).'" '.selected( $name, $instance['image_size'], FALSE ).'>'.esc_html( $name ).' ( '.$size['width'].'x'.$size['height'].' )</option>';
+							echo '<option value="' . esc_attr( $name ) . '"' . selected( $name, $instance['image_size'], FALSE ) . '>' . esc_html( $name ) . ' ( ' . absint( $size['width'] ) . 'x' . absint( $size['height'] ) . ' )</option>';
 						?>
 					</select>
 				</p>
 
 				<p>
-					<label for="<?php echo $this->get_field_id( 'image_alignment' ); ?>"><?php _e( 'Image Alignment', 'genesis-featured-custom-post-type-widget' ); ?>:</label>
-					<select id="<?php echo $this->get_field_id( 'image_alignment' ); ?>" name="<?php echo $this->get_field_name( 'image_alignment' ); ?>">
+					<label for="<?php echo esc_attr( $this->get_field_id( 'image_alignment' ) ); ?>"><?php _e( 'Image Alignment:', 'genesis-featured-custom-post-type-widget' ); ?> </label>
+					<select id="<?php echo esc_attr( $this->get_field_id( 'image_alignment' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'image_alignment' ) ); ?>">
 						<option value="alignnone">- <?php _e( 'None', 'genesis-featured-custom-post-type-widget' ); ?> -</option>
 						<option value="alignleft" <?php selected( 'alignleft', $instance['image_alignment'] ); ?>><?php _e( 'Left', 'genesis-featured-custom-post-type-widget' ); ?></option>
 						<option value="alignright" <?php selected( 'alignright', $instance['image_alignment'] ); ?>><?php _e( 'Right', 'genesis-featured-custom-post-type-widget' ); ?></option>
@@ -477,34 +477,34 @@ class Genesis_Featured_Custom_Post_Type extends WP_Widget {
 			<div class="genesis-widget-column-box genesis-widget-column-box-top">
 
 				<p>
-					<input id="<?php echo $this->get_field_id( 'show_title' ); ?>" type="checkbox" name="<?php echo $this->get_field_name( 'show_title' ); ?>" value="1" <?php checked( $instance['show_title'] ); ?>/>
-					<label for="<?php echo $this->get_field_id( 'show_title' ); ?>"><?php _e( 'Show Post Title', 'genesis-featured-custom-post-type-widget' ); ?></label>
+					<input id="<?php echo esc_attr( $this->get_field_id( 'show_title' ) ); ?>" type="checkbox" name="<?php echo esc_attr( $this->get_field_name( 'show_title' ) ); ?>" value="1" <?php checked( $instance['show_title'] ); ?>/>
+					<label for="<?php echo esc_attr( $this->get_field_id( 'show_title' ) ); ?>"><?php _e( 'Show Post Title', 'genesis-featured-custom-post-type-widget' ); ?></label>
 				</p>
 
 				<p>
-					<input id="<?php echo $this->get_field_id( 'show_byline' ); ?>" type="checkbox" name="<?php echo $this->get_field_name( 'show_byline' ); ?>" value="1" <?php checked( $instance['show_byline'] ); ?>/>
-					<label for="<?php echo $this->get_field_id( 'show_byline' ); ?>"><?php _e( 'Show Post Info', 'genesis-featured-custom-post-type-widget' ); ?></label>
-					<input type="text" id="<?php echo $this->get_field_id( 'post_info' ); ?>" name="<?php echo $this->get_field_name( 'post_info' ); ?>" value="<?php echo esc_attr( $instance['post_info'] ); ?>" class="widefat" />
+					<input id="<?php echo esc_attr( $this->get_field_id( 'show_byline' ) ); ?>" type="checkbox" name="<?php echo esc_attr( $this->get_field_name( 'show_byline' ) ); ?>" value="1" <?php checked( $instance['show_byline'] ); ?>/>
+					<label for="<?php echo esc_attr( $this->get_field_id( 'show_byline' ) ); ?>"><?php _e( 'Show Post Info', 'genesis-featured-custom-post-type-widget' ); ?></label>
+					<input type="text" id="<?php echo esc_attr( $this->get_field_id( 'post_info' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'post_info' ) ); ?>" value="<?php echo esc_attr( $instance['post_info'] ); ?>" class="widefat" />
 				</p>
 
 				<p>
-					<label for="<?php echo $this->get_field_id( 'show_content' ); ?>"><?php _e( 'Content Type', 'genesis-featured-custom-post-type-widget' ); ?>:</label>
-					<select id="<?php echo $this->get_field_id( 'show_content' ); ?>" name="<?php echo $this->get_field_name( 'show_content' ); ?>">
+					<label for="<?php echo esc_attr( $this->get_field_id( 'show_content' ) ); ?>"><?php _e( 'Content Type:', 'genesis-featured-custom-post-type-widget' ); ?> </label>
+					<select id="<?php echo esc_attr( $this->get_field_id( 'show_content' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'show_content' ) ); ?>">
 						<option value="content" <?php selected( 'content', $instance['show_content'] ); ?>><?php _e( 'Show Content', 'genesis-featured-custom-post-type-widget' ); ?></option>
 						<option value="excerpt" <?php selected( 'excerpt', $instance['show_content'] ); ?>><?php _e( 'Show Excerpt', 'genesis-featured-custom-post-type-widget' ); ?></option>
 						<option value="content-limit" <?php selected( 'content-limit', $instance['show_content'] ); ?>><?php _e( 'Show Content Limit', 'genesis-featured-custom-post-type-widget' ); ?></option>
 						<option value="" <?php selected( '', $instance['show_content'] ); ?>><?php _e( 'No Content', 'genesis-featured-custom-post-type-widget' ); ?></option>
 					</select>
 					<br />
-					<label for="<?php echo $this->get_field_id( 'content_limit' ); ?>"><?php _e( 'Limit content to', 'genesis-featured-custom-post-type-widget' ); ?>
-						<input type="text" id="<?php echo $this->get_field_id( 'image_alignment' ); ?>" name="<?php echo $this->get_field_name( 'content_limit' ); ?>" value="<?php echo esc_attr( intval( $instance['content_limit'] ) ); ?>" size="3" />
+					<label for="<?php echo esc_attr( $this->get_field_id( 'content_limit' ) ); ?>"><?php _e( 'Limit content to', 'genesis-featured-custom-post-type-widget' ); ?>
+						<input type="text" id="<?php echo esc_attr( $this->get_field_id( 'image_alignment' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'content_limit' ) ); ?>" value="<?php echo esc_attr( intval( $instance['content_limit'] ) ); ?>" size="3" />
 						<?php _e( 'characters', 'genesis-featured-custom-post-type-widget' ); ?>
 					</label>
 				</p>
 
 				<p>
-					<label for="<?php echo $this->get_field_id( 'more_text' ); ?>"><?php _e( 'More Text (if applicable)', 'genesis-featured-custom-post-type-widget' ); ?>:</label>
-					<input type="text" id="<?php echo $this->get_field_id( 'more_text' ); ?>" name="<?php echo $this->get_field_name( 'more_text' ); ?>" value="<?php echo esc_attr( $instance['more_text'] ); ?>" />
+					<label for="<?php echo esc_attr( $this->get_field_id( 'more_text' ) ); ?>"><?php _e( 'More Text (if applicable):', 'genesis-featured-custom-post-type-widget' ); ?> </label>
+					<input type="text" id="<?php echo esc_attr( $this->get_field_id( 'more_text' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'more_text' ) ); ?>" value="<?php echo esc_attr( $instance['more_text'] ); ?>" />
 				</p>
 
 			</div>
@@ -514,13 +514,13 @@ class Genesis_Featured_Custom_Post_Type extends WP_Widget {
 				<p><?php _e( 'To display an unordered list of more posts from this category, please fill out the information below', 'genesis-featured-custom-post-type-widget' ); ?>:</p>
 
 				<p>
-					<label for="<?php echo $this->get_field_id( 'extra_title' ); ?>"><?php _e( 'Title', 'genesis-featured-custom-post-type-widget' ); ?>:</label>
-					<input type="text" id="<?php echo $this->get_field_id( 'extra_title' ); ?>" name="<?php echo $this->get_field_name( 'extra_title' ); ?>" value="<?php echo esc_attr( $instance['extra_title'] ); ?>" class="widefat" />
+					<label for="<?php echo esc_attr( $this->get_field_id( 'extra_title' ) ); ?>"><?php _e( 'Title:', 'genesis-featured-custom-post-type-widget' ); ?> </label>
+					<input type="text" id="<?php echo esc_attr( $this->get_field_id( 'extra_title' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'extra_title' ) ); ?>" value="<?php echo esc_attr( $instance['extra_title'] ); ?>" class="widefat" />
 				</p>
 
 				<p>
-					<label for="<?php echo $this->get_field_id( 'extra_num' ); ?>"><?php _e( 'Number of Posts to Show', 'genesis-featured-custom-post-type-widget' ); ?>:</label>
-					<input type="text" id="<?php echo $this->get_field_id( 'extra_num' ); ?>" name="<?php echo $this->get_field_name( 'extra_num' ); ?>" value="<?php echo esc_attr( $instance['extra_num'] ); ?>" size="2" />
+					<label for="<?php echo esc_attr( $this->get_field_id( 'extra_num' ) ); ?>"><?php _e( 'Number of Posts to Show:', 'genesis-featured-custom-post-type-widget' ); ?> </label>
+					<input type="text" id="<?php echo esc_attr( $this->get_field_id( 'extra_num' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'extra_num' ) ); ?>" value="<?php echo esc_attr( $instance['extra_num'] ); ?>" size="2" />
 				</p>
 
 			</div>
@@ -528,22 +528,22 @@ class Genesis_Featured_Custom_Post_Type extends WP_Widget {
 			<div class="genesis-widget-column-box">
 
 				<p>
-					<input id="<?php echo $this->get_field_id( 'more_from_category' ); ?>" type="checkbox" name="<?php echo $this->get_field_name( 'more_from_category' ); ?>" value="1" <?php checked( $instance['more_from_category'] ); ?>/>
-					<label for="<?php echo $this->get_field_id( 'more_from_category' ); ?>"><?php _e( 'Show Category Archive Link', 'genesis-featured-custom-post-type-widget' ); ?></label>
+					<input id="<?php echo esc_attr( $this->get_field_id( 'more_from_category' ) ); ?>" type="checkbox" name="<?php echo esc_attr( $this->get_field_name( 'more_from_category' ) ); ?>" value="1" <?php checked( $instance['more_from_category'] ); ?>/>
+					<label for="<?php echo esc_attr( $this->get_field_id( 'more_from_category' ) ); ?>"><?php _e( 'Show Category Archive Link', 'genesis-featured-custom-post-type-widget' ); ?></label>
 				</p>
 
 				<p>
-					<label for="<?php echo $this->get_field_id( 'more_from_category_text' ); ?>"><?php _e( 'Link Text', 'genesis-featured-custom-post-type-widget' ); ?>:</label>
-					<input type="text" id="<?php echo $this->get_field_id( 'more_from_category_text' ); ?>" name="<?php echo $this->get_field_name( 'more_from_category_text' ); ?>" value="<?php echo esc_attr( $instance['more_from_category_text'] ); ?>" class="widefat" />
+					<label for="<?php echo esc_attr( $this->get_field_id( 'more_from_category_text' ) ); ?>"><?php _e( 'Link Text:', 'genesis-featured-custom-post-type-widget' ); ?> </label>
+					<input type="text" id="<?php echo esc_attr( $this->get_field_id( 'more_from_category_text' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'more_from_category_text' ) ); ?>" value="<?php echo esc_attr( $instance['more_from_category_text'] ); ?>" class="widefat" />
 				</p>
 
 				<p>
-					<input id="<?php echo $this->get_field_id( 'archive_link' ); ?>" type="checkbox" name="<?php echo $this->get_field_name( 'archive_link' ); ?>" value="1" <?php checked( $instance['archive_link'] ); ?>/>
-					<label for="<?php echo $this->get_field_id( 'archive_link' ); ?>"><?php _e( 'Show Archive Link', 'genesis-featured-sermon-widget' ); ?></label>
+					<input id="<?php echo esc_attr( $this->get_field_id( 'archive_link' ) ); ?>" type="checkbox" name="<?php echo esc_attr( $this->get_field_name( 'archive_link' ) ); ?>" value="1" <?php checked( $instance['archive_link'] ); ?>/>
+					<label for="<?php echo esc_attr( $this->get_field_id( 'archive_link' ) ); ?>"><?php _e( 'Show Archive Link', 'genesis-featured-custom-post-type-widget' ); ?></label>
 				</p>
 				<p>
-					<label for="<?php echo $this->get_field_id( 'archive_text' ); ?>"><?php _e( 'Link Text', 'genesis-featured-custom-post-type-widget' ); ?>:</label>
-					<input type="text" id="<?php echo $this->get_field_id( 'archive_text' ); ?>" name="<?php echo $this->get_field_name( 'archive_text' ); ?>" value="<?php echo esc_attr( $instance['archive_text'] ); ?>" class="widefat" />
+					<label for="<?php echo esc_attr( $this->get_field_id( 'archive_text' ) ); ?>"><?php _e( 'Link Text:', 'genesis-featured-custom-post-type-widget' ); ?> </label>
+					<input type="text" id="<?php echo esc_attr( $this->get_field_id( 'archive_text' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'archive_text' ) ); ?>" value="<?php echo esc_attr( $instance['archive_text'] ); ?>" class="widefat" />
 				</p>
 
 			</div>
@@ -571,8 +571,7 @@ class Genesis_Featured_Custom_Post_Type extends WP_Widget {
 			'_builtin' => false,
 		);
 		$output = 'names';
-		$operator = 'and';
-		$item->post_type_list = get_post_types( $args, $output, $operator );
+		$item->post_type_list = get_post_types( $args, $output );
 
 		//* Add posts to that post_type_list
 		$item->post_type_list['post'] = 'post';

--- a/includes/class-featured-custom-post-type-widget-registrations.php
+++ b/includes/class-featured-custom-post-type-widget-registrations.php
@@ -154,7 +154,7 @@ class Genesis_Featured_Custom_Post_Type extends WP_Widget {
 			}
 
 			genesis_markup( array(
-				'html5'   => '<div class="' . $column_class . '"><article>',
+				'html5'   => '<div class="' . $column_class . '"><article %s>',
 				'xhtml'   => sprintf( '<div class="%s ' . $column_class . '">', implode( ' ', get_post_class() ) ),
 				'context' => 'entry',
 			) );

--- a/includes/class-featured-custom-post-type-widget-registrations.php
+++ b/includes/class-featured-custom-post-type-widget-registrations.php
@@ -17,7 +17,6 @@
 * Pete has added support for Custom Taxonomies.
 */
 
-
 class Genesis_Featured_Custom_Post_Type extends WP_Widget {
 
 	/**
@@ -42,6 +41,7 @@ class Genesis_Featured_Custom_Post_Type extends WP_Widget {
 			'posts_offset'            => 0,
 			'orderby'                 => '',
 			'order'                   => '',
+			'columns'                 => 'full',
 			'exclude_displayed'       => 0,
 			'show_image'              => 0,
 			'image_alignment'         => '',
@@ -79,6 +79,7 @@ class Genesis_Featured_Custom_Post_Type extends WP_Widget {
 		// Register our Ajax handler
 		add_action( 'wp_ajax_tax_term_action', array( $this, 'tax_term_action_callback' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'admin_enqueue' ) );
+
 	}
 
 	/**
@@ -130,13 +131,31 @@ class Genesis_Featured_Custom_Post_Type extends WP_Widget {
 
 		$wp_query = new WP_Query( $query_args );
 
+		$i = 0;
+
 		if ( have_posts() ) : while ( have_posts() ) : the_post();
 
 			$_genesis_displayed_ids[] = get_the_ID();
 
+			$column_class = $instance['columns'];
+			$count        = 1;
+			if ( 'one-half' === $instance['columns'] ) {
+				$count = 2;
+			} elseif ( 'one-third' === $instance['columns'] ) {
+				$count = 3;
+			} elseif ( 'one-fourth' === $instance['columns'] ) {
+				$count = 4;
+			} elseif ( 'one-sixth' === $instance['columns'] ) {
+				$count = 6;
+			}
+
+			if ( $i++ % $count === 0 ) {
+				$column_class = $instance['columns'] . ' first';
+			}
+
 			genesis_markup( array(
-				'html5'   => '<article %s>',
-				'xhtml'   => sprintf( '<div class="%s">', implode( ' ', get_post_class() ) ),
+				'html5'   => '<div class="' . $column_class . '"><article>',
+				'xhtml'   => sprintf( '<div class="%s ' . $column_class . '">', implode( ' ', get_post_class() ) ),
 				'context' => 'entry',
 			) );
 
@@ -202,7 +221,7 @@ class Genesis_Featured_Custom_Post_Type extends WP_Widget {
 			}
 
 			genesis_markup( array(
-				'html5' => '</article>',
+				'html5' => '</article></div>',
 				'xhtml' => '</div>',
 			) );
 
@@ -413,6 +432,17 @@ class Genesis_Featured_Custom_Post_Type extends WP_Widget {
 					<label for="<?php echo $this->get_field_id( 'exclude_displayed' ); ?>"><?php _e( 'Exclude Previously Displayed Posts?', 'genesis-featured-custom-post-type-widget' ); ?></label>
 				</p>
 
+				<p>
+					<label for="<?php echo $this->get_field_id( 'columns' ); ?>"><?php _e( 'Number of Columns', 'sawrie-cpt' ); ?>:</label>
+					<select id="<?php echo $this->get_field_id( 'columns' ); ?>" name="<?php echo $this->get_field_name( 'columns' ); ?>">
+						<option value="full" <?php selected( 'full', $instance['columns'] ); ?>>1</option>
+						<option value="one-half" <?php selected( 'one-half', $instance['columns'] ); ?>>2</option>
+						<option value="one-third" <?php selected( 'one-third', $instance['columns'] ); ?>>3</option>
+						<option value="one-fourth" <?php selected( 'one-fourth', $instance['columns'] ); ?>>4</option>
+						<option value="one-sixth" <?php selected( 'one-sixth', $instance['columns'] ); ?>>6</option>
+					</select>
+				</p>
+
 			</div>
 
 			<div class="genesis-widget-column-box">
@@ -612,4 +642,5 @@ class Genesis_Featured_Custom_Post_Type extends WP_Widget {
 		echo json_encode( $taxes );
 		die();
 	}
+
 }

--- a/languages/featured-custom-post-type-widget-for-genesis.pot
+++ b/languages/featured-custom-post-type-widget-for-genesis.pot
@@ -1,0 +1,244 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: Featured Custom Post Type Widget for Genesis 2.0.0\n"
+"POT-Creation-Date: 2015-01-11 15:32-0500\n"
+"PO-Revision-Date: 2015-01-11 15:34-0500\n"
+"Last-Translator: Robin Cornett <hello@robincornett.com>\n"
+"Language-Team: Robin Cornett <hello@robincornett.com>\n"
+"Language: en_US\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 1.7.3\n"
+"X-Poedit-Basepath: ..\n"
+"X-Poedit-SourceCharset: UTF-8\n"
+"X-Poedit-KeywordsList: __;_e;_n:1,2;_x:1,2c;_ex:1,2c;_nx:4c,1,2;esc_attr__;"
+"esc_attr_e;esc_attr_x:1,2c;esc_html__;esc_html_e;esc_html_x:1,2c;"
+"_n_noop:1,2;_nx_noop:3c,1,2;__ngettext_noop:1,2\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Poedit-SearchPath-0: .\n"
+"X-Poedit-SearchPathExcluded-0: *.js\n"
+
+#: featured-custom-post-type-widget.php:42
+msgid ""
+"<strong>Featured Custom Post Type Widget For Genesis</strong> works only "
+"with the Genesis Framework. It has been <strong>deactivated</strong>."
+msgstr ""
+
+#: includes/class-featured-custom-post-type-widget-registrations.php:54
+msgid "By"
+msgstr ""
+
+#: includes/class-featured-custom-post-type-widget-registrations.php:57
+msgid "[Read More...]"
+msgstr ""
+
+#: includes/class-featured-custom-post-type-widget-registrations.php:61
+msgid "More Posts from this Category"
+msgstr ""
+
+#: includes/class-featured-custom-post-type-widget-registrations.php:63
+msgid "View Custom Post Type Archive"
+msgstr ""
+
+#: includes/class-featured-custom-post-type-widget-registrations.php:68
+msgid "Displays featured custom post types with thumbnails"
+msgstr ""
+
+#: includes/class-featured-custom-post-type-widget-registrations.php:77
+msgid "Featured Custom Post Types for Genesis"
+msgstr ""
+
+#: includes/class-featured-custom-post-type-widget-registrations.php:328
+#: includes/class-featured-custom-post-type-widget-registrations.php:517
+msgid "Title:"
+msgstr ""
+
+#: includes/class-featured-custom-post-type-widget-registrations.php:337
+msgid "Post Type:"
+msgstr ""
+
+#: includes/class-featured-custom-post-type-widget-registrations.php:341
+#: includes/class-featured-custom-post-type-widget-registrations.php:355
+msgid "any"
+msgstr ""
+
+#: includes/class-featured-custom-post-type-widget-registrations.php:351
+msgid "Category/Term:"
+msgstr ""
+
+#: includes/class-featured-custom-post-type-widget-registrations.php:367
+#: includes/class-featured-custom-post-type-widget-registrations.php:522
+msgid "Number of Posts to Show:"
+msgstr ""
+
+#: includes/class-featured-custom-post-type-widget-registrations.php:372
+msgid "Number of Posts to Offset:"
+msgstr ""
+
+#: includes/class-featured-custom-post-type-widget-registrations.php:377
+msgid "Order By:"
+msgstr ""
+
+#: includes/class-featured-custom-post-type-widget-registrations.php:379
+msgid "Date"
+msgstr ""
+
+#: includes/class-featured-custom-post-type-widget-registrations.php:380
+msgid "Title"
+msgstr ""
+
+#: includes/class-featured-custom-post-type-widget-registrations.php:381
+msgid "Parent"
+msgstr ""
+
+#: includes/class-featured-custom-post-type-widget-registrations.php:382
+msgid "ID"
+msgstr ""
+
+#: includes/class-featured-custom-post-type-widget-registrations.php:383
+msgid "Comment Count"
+msgstr ""
+
+#: includes/class-featured-custom-post-type-widget-registrations.php:384
+msgid "Random"
+msgstr ""
+
+#: includes/class-featured-custom-post-type-widget-registrations.php:389
+msgid "Sort Order:"
+msgstr ""
+
+#: includes/class-featured-custom-post-type-widget-registrations.php:391
+msgid "Descending (3, 2, 1)"
+msgstr ""
+
+#: includes/class-featured-custom-post-type-widget-registrations.php:392
+msgid "Ascending (1, 2, 3)"
+msgstr ""
+
+#: includes/class-featured-custom-post-type-widget-registrations.php:398
+msgid "Exclude Previously Displayed Posts?"
+msgstr ""
+
+#: includes/class-featured-custom-post-type-widget-registrations.php:402
+msgid "Number of Columns:"
+msgstr ""
+
+#: includes/class-featured-custom-post-type-widget-registrations.php:418
+msgid "Show Author Gravatar"
+msgstr ""
+
+#: includes/class-featured-custom-post-type-widget-registrations.php:422
+msgid "Gravatar Size:"
+msgstr ""
+
+#: includes/class-featured-custom-post-type-widget-registrations.php:424
+msgid "Small (45px)"
+msgstr ""
+
+#: includes/class-featured-custom-post-type-widget-registrations.php:425
+msgid "Medium (65px)"
+msgstr ""
+
+#: includes/class-featured-custom-post-type-widget-registrations.php:426
+msgid "Large (85px)"
+msgstr ""
+
+#: includes/class-featured-custom-post-type-widget-registrations.php:427
+msgid "Extra Large (125px)"
+msgstr ""
+
+#: includes/class-featured-custom-post-type-widget-registrations.php:432
+msgid "Gravatar Alignment:"
+msgstr ""
+
+#: includes/class-featured-custom-post-type-widget-registrations.php:434
+#: includes/class-featured-custom-post-type-widget-registrations.php:464
+msgid "None"
+msgstr ""
+
+#: includes/class-featured-custom-post-type-widget-registrations.php:435
+#: includes/class-featured-custom-post-type-widget-registrations.php:465
+msgid "Left"
+msgstr ""
+
+#: includes/class-featured-custom-post-type-widget-registrations.php:436
+#: includes/class-featured-custom-post-type-widget-registrations.php:466
+msgid "Right"
+msgstr ""
+
+#: includes/class-featured-custom-post-type-widget-registrations.php:437
+#: includes/class-featured-custom-post-type-widget-registrations.php:467
+msgid "Center"
+msgstr ""
+
+#: includes/class-featured-custom-post-type-widget-registrations.php:447
+msgid "Show Featured Image"
+msgstr ""
+
+#: includes/class-featured-custom-post-type-widget-registrations.php:451
+msgid "Image Size:"
+msgstr ""
+
+#: includes/class-featured-custom-post-type-widget-registrations.php:462
+msgid "Image Alignment:"
+msgstr ""
+
+#: includes/class-featured-custom-post-type-widget-registrations.php:481
+msgid "Show Post Title"
+msgstr ""
+
+#: includes/class-featured-custom-post-type-widget-registrations.php:486
+msgid "Show Post Info"
+msgstr ""
+
+#: includes/class-featured-custom-post-type-widget-registrations.php:491
+msgid "Content Type:"
+msgstr ""
+
+#: includes/class-featured-custom-post-type-widget-registrations.php:493
+msgid "Show Content"
+msgstr ""
+
+#: includes/class-featured-custom-post-type-widget-registrations.php:494
+msgid "Show Excerpt"
+msgstr ""
+
+#: includes/class-featured-custom-post-type-widget-registrations.php:495
+msgid "Show Content Limit"
+msgstr ""
+
+#: includes/class-featured-custom-post-type-widget-registrations.php:496
+msgid "No Content"
+msgstr ""
+
+#: includes/class-featured-custom-post-type-widget-registrations.php:499
+msgid "Limit content to"
+msgstr ""
+
+#: includes/class-featured-custom-post-type-widget-registrations.php:501
+msgid "characters"
+msgstr ""
+
+#: includes/class-featured-custom-post-type-widget-registrations.php:506
+msgid "More Text (if applicable):"
+msgstr ""
+
+#: includes/class-featured-custom-post-type-widget-registrations.php:514
+msgid ""
+"To display an unordered list of more posts from this category, please fill "
+"out the information below"
+msgstr ""
+
+#: includes/class-featured-custom-post-type-widget-registrations.php:532
+msgid "Show Category Archive Link"
+msgstr ""
+
+#: includes/class-featured-custom-post-type-widget-registrations.php:536
+#: includes/class-featured-custom-post-type-widget-registrations.php:545
+msgid "Link Text:"
+msgstr ""
+
+#: includes/class-featured-custom-post-type-widget-registrations.php:542
+msgid "Show Archive Link"
+msgstr ""


### PR DESCRIPTION
The primary purpose of this PR is to include column classes in the widget. Other changes include fixing some of the ajax issues, text domains, and adding the .pot file for translators.