### PR TITLE
Pull Req for 2.1.1 - Fixes and changes to display

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,12 @@ Thank you to <a href="https://github.com/robincornett">Robin Cornett</a> for all
 
 ### Changelog
 
+#### 2.1.1
+* fix: ensure select-box widths will not overrun widget space
+* new: post type displays by name instead of slug
+* new: cat/tax list displays name instead of slug
+* security: improved sanitization and validation
+
 #### 2.1.0
 * added filter for featured post image
 * added filter for extra posts list

--- a/featured-custom-post-type-widget.php
+++ b/featured-custom-post-type-widget.php
@@ -9,7 +9,7 @@
  * Plugin Name: Featured Custom Post Type Widget for Genesis
  * Plugin URI:  http://calliaweb.co.uk/featured-custom-post-type-widget-genesis/
  * Description: Widget to Display Featured Custom Post Types - uses code from Genesis Featured Post Widget and adds support for custom post types and custom taxonomies
- * Version:     2.1.0
+ * Version:     2.1.1
  * Author:      Jo Waltham
  * Author URI:  http://calliaweb.co.uk/
  * Text Domain: featured-custom-post-type-widget-for-genesis


### PR DESCRIPTION
I forked this to fix an issue with select boxes overrunning widget space (I had some long slugs),but also to change slugs to names on display, and sanitize some things.
- fix: ensure select-box widths will not overrun widget space
- new: post type displays by name instead of slug
- new: cat/tax list displays name instead of slug
- security: improved sanitization and validation
